### PR TITLE
Chart fixes

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,4 +6,3 @@ RUN yarn generate --dotenv .env.prod
 
 FROM cgr.dev/chainguard/nginx:latest
 COPY --from=builder /build/dist /usr/share/nginx/html
-EXPOSE 8080

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+          - name: nginx-config
+            mountPath: /etc/nginx/conf.d/nginx.default.conf
+            subPath: nginx.default.conf
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -47,6 +51,10 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ include "carbide-registry-dashboard.fullname" . }}-nginx-config
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/chart/templates/nginx-config.yaml
+++ b/chart/templates/nginx-config.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "carbide-registry-dashboard.fullname" . }}-nginx-config
+data:
+    nginx.default.conf: |
+      server {
+          listen       8080;
+          server_name  localhost;
+          port_in_redirect off;
+
+          #access_log  /var/log/nginx/host.access.log  main;
+
+          location / {
+              root   /usr/share/nginx/html;
+              index  index.html index.htm;
+              try_files $uri $uri/ /index.html;
+          }
+
+          #error_page  404              /404.html;
+
+          # redirect server error pages to the static page /50x.html
+          #
+          error_page   500 502 503 504  /50x.html;
+          location = /50x.html {
+              root   /usr/share/nginx/html;
+          }
+      }


### PR DESCRIPTION
- nginx was redirecting to :8080 of the exposed url, this has been fixed
- nginx now redirects any "missing" pages to their rightful .html file